### PR TITLE
fix(clustertool): Flux postBuild 

### DIFF
--- a/embed/generic/kubernetes/flux-entry.yaml
+++ b/embed/generic/kubernetes/flux-entry.yaml
@@ -35,8 +35,6 @@ spec:
             substituteFrom:
               - kind: ConfigMap
                 name: cluster-config
-              - kind: ConfigMap
-                name: upgrade-settings
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->
With upgrading to tuppr, configmap removed.
So now this needs to be gone as well to resolve for example:
`post build failed for 'Namespace.v1.[noGrp]/clusterissuer': substitute from 'ConfigMap/upgrade-settings' error: configmaps "upgrade-settings" not foundd`
**⚙️ Type of change**

- [ ] 🆕 New feature (e.g., bootstrap, cluster config, or automation)
- [x] 🐛 Bugfix (e.g., node setup, config generation)
- [ ] 🔃 Chart Updates/Changes included with clustertool
- [ ] 🔃 Refactor (internal changes, no functional impact)
- [ ] ⚠️ Breaking change (changes Talos cluster behavior)

**🧪 How Has This Been Tested?**
<!--
Describe how you verified the change. Include steps to reproduce on a Talos cluster.
-->
- [ ] Run clustertool commands locally
- [ ] Verified cluster bootstrap on Talos nodes
- [ ] Checked generated configs are valid
- [ ] Validated cluster state after changes

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ Followed project style and contribution guidelines
- [ ] 👀 Self-reviewed my changes
- [ ] 🧪 Documented testing steps
- [ ] 🏷️ PR title follows convention:
  - `feat(clustertool):`
  - `fix(clustertool):`
  - `chore(clustertool):`

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
